### PR TITLE
Add Prisma in Cache

### DIFF
--- a/Dockerfile.cache
+++ b/Dockerfile.cache
@@ -9,4 +9,5 @@ RUN npm install -g pnpm@9.15.2
 
 # Copy package files and install dependencies
 COPY pnpm-lock.yaml package.json ./
+COPY prisma ./prisma
 RUN pnpm install


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile.cache` file. The change adds a line to copy the `prisma` directory before running the `pnpm install` command.

* [`Dockerfile.cache`](diffhunk://#diff-0837edc0090616b607dc5b2e0d7ab72efd8b2e0a53b57b11f9826253c564d86dR12): Added a line to copy the `prisma` directory before running the `pnpm install` command.…tion