### PR TITLE
GitHub Actions workflows security fixes

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -7,6 +7,10 @@ jobs:
   client-build-and-push:
     runs-on: ubuntu-latest
     environment: Cache
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
     env:
       ENVIRONMENT: Cache
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -24,13 +28,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }} 
           password: ${{ env.DOCKER_PASSWORD }} 
 
       - name: Build cache image and push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         with:
           context: .
           file: ./Dockerfile.cache

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -56,7 +56,7 @@ jobs:
       run: pnpm migrate
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
       with:
         registry: https://index.docker.io/v1/
         username: ${{ env.DOCKER_USERNAME }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,7 +55,7 @@ jobs:
       
       - name: Push changes
         if: steps.commit_changes.outputs.committed == 'true'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,14 +33,14 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
       with:
         registry: https://index.docker.io/v1/
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}
 
     - name: Build client image and push to Docker Hub
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
       with:
         context: .
         file: ./Dockerfile


### PR DESCRIPTION
**Closes #12
Closes #11 
Closes #10 
Closes #9 
Closes #8 
Closes #7 
Closes #6** 

This pull request includes several updates to the GitHub Actions workflows, primarily focusing on updating dependencies to specific commit hashes and adding permissions to the `client-build-and-push` job.

Updates to dependencies and permissions:

* [`.github/workflows/cache.yml`](diffhunk://#diff-f5215bed3ca2aa882b75e728bfe2ae3725f031ceb1246c8d5c25947e706e90f2R10-R13): Added write permissions for `contents`, `pull-requests`, and `checks` in the `client-build-and-push` job.
* [`.github/workflows/cache.yml`](diffhunk://#diff-f5215bed3ca2aa882b75e728bfe2ae3725f031ceb1246c8d5c25947e706e90f2L27-R37): Updated `docker/login-action` to a specific commit hash for version v3 and `docker/build-push-action` to a specific commit hash for version v6.10.0.
* [`.github/workflows/production.yml`](diffhunk://#diff-d5171f9b8c42863b1e934fda1fefedf968913c65aa5d715555a696fb3cbd4c7eL59-R59): Updated `docker/login-action` to a specific commit hash for version v3.
* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L58-R58): Updated `ad-m/github-push-action` to a specific commit hash for the master branch.
* [`.github/workflows/staging.yml`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bL36-R43): Updated `docker/login-action` to a specific commit hash for version v3 and `docker/build-push-action` to a specific commit hash for version v6.10.0.…d permissions