### PR TITLE
Remove server-side rendering option for Datadog initialization

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,7 @@ import { ClerkProvider } from '@clerk/nextjs';
 import { SEO } from '@/constants';
 import dynamic from 'next/dynamic';
 
-const DatadogInit = dynamic(() => import('@/components/misc/datadog-init'), {
-  ssr: false
-});
+const DatadogInit = dynamic(() => import('@/components/misc/datadog-init'));
 
 const poppinsSans = Poppins({
   variable: '--font-poppins-sans',


### PR DESCRIPTION
This pull request includes a change to the `src/app/layout.tsx` file to simplify the import of the `DatadogInit` component by removing the `ssr` option.

Codebase simplification:

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L8-R8): Removed the `ssr` option from the dynamic import of the `DatadogInit` component.