### PR TITLE
Add database availability check to migration workflow

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -47,6 +47,29 @@ jobs:
             --relational-database-name merchtrack-db-sgp1 \
             --publicly-accessible
 
+      - name: Wait for Database Availability
+        run: |
+          MAX_ATTEMPTS=30
+          ATTEMPT=1
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            DB_STATUS=$(aws lightsail get-relational-database --relational-database-name merchtrack-db-sgp1 | jq -r '.relationalDatabase.state')
+            
+            if [ "$DB_STATUS" = "available" ]; then
+              echo "Database is available!"
+              break
+            fi
+            
+            echo "Attempt $ATTEMPT: Database status is $DB_STATUS. Waiting 10 seconds..."
+            sleep 10
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+          
+          if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
+            echo "Database did not become available within the timeout period"
+            exit 1
+          fi
+
       - name: Create Database Backup
         uses: tj-actions/pg-dump@c826d55715b153f5572006e464e69b2bf0422fea # v3.0.1
         with:


### PR DESCRIPTION
This pull request includes a significant update to the `.github/workflows/migrate.yml` file. The main change involves adding a new step to wait for the database to become available before proceeding with the rest of the workflow. 

The most important changes include:

* [`.github/workflows/migrate.yml`](diffhunk://#diff-63159f731de7c1af84c116928177ddc31d758eff392e558704d7772b2dcc4e33R50-R72): Added a new step named "Wait for Database Availability" which includes a loop that checks the database status up to 30 times, waiting 10 seconds between each attempt. If the database does not become available within this period, the script exits with an error.