### PR TITLE
Add environment variables for Redis and Mailgun

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -44,6 +44,7 @@ jobs:
         SENTRY_TRACES_SAMPLE_RATE: ${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}
       run: |
           cat << EOF > .env
+          NEXT_RUNTIME=${NEXT_RUNTIME}
           APP_ENV=${APP_ENV}
           NODE_ENV=${NODE_ENV}
           NEXT_PUBLIC_NODE_ENV=${NEXT_PUBLIC_NODE_ENV}
@@ -58,6 +59,11 @@ jobs:
           SENTRY_DSN=${SENTRY_DSN}
           SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
           SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE}
+          REDIS_HOST=${REDIS_HOST}
+          REDIS_PORT=${REDIS_PORT}
+          REDIS_PASSWORD=${REDIS_PASSWORD}
+          MAILGUN_API_KEY=${MAILGUN_API_KEY}
+          MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
           EOF
 
     - name: Log in to Docker Hub


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/staging.yml` file, specifically adding new environment variables to the workflow configuration.

Environment variable additions:

* Added `NEXT_RUNTIME` to the `.env` file creation step.
* Added `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `MAILGUN_API_KEY`, and `MAILGUN_DOMAIN` to the `.env` file creation step.…flow