### PR TITLE
Remove env checking

### DIFF
--- a/src/lib/mailgun.ts
+++ b/src/lib/mailgun.ts
@@ -2,9 +2,6 @@ import formData from 'form-data';
 import Mailgun, { type MessagesSendResult } from 'mailgun.js';
 
 const mailgunClientSingleton = () => {
-  if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
-    throw new Error('Mailgun API key or domain is missing.');
-  }
   const mailgun = new Mailgun(formData);
   return mailgun.client({
     username: 'api',

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,9 +1,6 @@
 import Redis from 'ioredis';
 
 const redisClientSingleton = () => {
-  if (!process.env.REDIS_HOST || !process.env.REDIS_PORT || !process.env.REDIS_PASSWORD) {
-    throw new Error('Missing one or more required environment variables for Redis');
-  }
   return new Redis({
     host: process.env.REDIS_HOST,
     port: Number(process.env.REDIS_PORT),


### PR DESCRIPTION
This pull request includes changes to remove environment variable checks from the singleton client functions for Mailgun and Redis. These changes simplify the initialization process by assuming that the required environment variables are always set.

Simplification of initialization process:

* [`src/lib/mailgun.ts`](diffhunk://#diff-5aeab6e0f8593a5b228ef6c58993e59f043b75f24885a11cc5c8d046cdbe59f1L5-L7): Removed the check for `MAILGUN_API_KEY` and `MAILGUN_DOMAIN` environment variables in the `mailgunClientSingleton` function.
* [`src/lib/redis.ts`](diffhunk://#diff-241aa208b5b389faaa4354575e78e4ffa89d91858ce1590c3ba1f166814a121dL4-L6): Removed the check for `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD` environment variables in the `redisClientSingleton` function.