### PR TITLE
Add env for Redis and Mailgun in staging workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -42,6 +42,12 @@ jobs:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_TRACES_SAMPLE_RATE: ${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}
+        NEXT_RUNTIME: ${{ secrets.NEXT_RUNTIME }}
+        REDIS_HOST: ${{ secrets.REDIS_HOST }}
+        REDIS_PORT: ${{ secrets.REDIS_PORT }}
+        REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+        MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+        MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
       run: |
           cat << EOF > .env
           NEXT_RUNTIME=${NEXT_RUNTIME}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/staging.yml` file to add new environment variables necessary for the staging environment.

Environment variables added:

* [`NEXT_RUNTIME`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR45-R50): Added to the list of secrets for the staging environment.
* [`REDIS_HOST`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR45-R50): Added to the list of secrets for the staging environment.
* [`REDIS_PORT`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR45-R50): Added to the list of secrets for the staging environment.
* [`REDIS_PASSWORD`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR45-R50): Added to the list of secrets for the staging environment.
* [`MAILGUN_API_KEY`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR45-R50): Added to the list of secrets for the staging environment.
* [`MAILGUN_DOMAIN`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR45-R50): Added to the list of secrets for the staging environment.