### PR TITLE
fix: add Clerk secret key to staging workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -48,6 +48,7 @@ jobs:
         REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
         MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
         MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
+        CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       run: |
           cat << EOF > .env
           NEXT_RUNTIME=${NEXT_RUNTIME}
@@ -70,6 +71,7 @@ jobs:
           REDIS_PASSWORD=${REDIS_PASSWORD}
           MAILGUN_API_KEY=${MAILGUN_API_KEY}
           MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
+          CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
           EOF
 
     - name: Log in to Docker Hub


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/staging.yml` file to add a new environment variable for the Clerk secret key.

Environment variable addition:

* Added `CLERK_SECRET_KEY` to the list of environment variables in the `jobs:` section of the `.github/workflows/staging.yml` file to ensure it is available during the workflow execution. [[1]](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR51) [[2]](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR74)