### PR TITLE
Add revalidation settings to multiple pages and dynamic sitemap

### DIFF
--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -2,6 +2,8 @@ import ContactForm from "@/app/(public)/contact/(components)/contact-form";
 import PageAnimation from "@/components/public/page-animation";
 import PageTitle from "@/components/public/page-title";
 
+export const revalidate = 900;
+
 const ContactPage = () => {
   return (
     <PageAnimation className="max-w-4xl">

--- a/src/app/(public)/how-it-works/page.tsx
+++ b/src/app/(public)/how-it-works/page.tsx
@@ -8,6 +8,8 @@ export const metadata: Metadata = {
   description: 'Learn how to use MerchTrack in an interactive step-by-step guide.',
 };
 
+export const revalidate = 86400;
+
 export default function HowItWorksPage() {
   return (
     <PageAnimation className="max-w-5xl">

--- a/src/app/(public)/privacy-policy/page.tsx
+++ b/src/app/(public)/privacy-policy/page.tsx
@@ -3,6 +3,8 @@ import { PRIVACY_POLICY_CONTENT } from '@/constants';
 import PageTitle from '@/components/public/page-title';
 import PageAnimation from '@/components/public/page-animation';
 
+export const revalidate = 86400;
+
 const Page: React.FC = () => {
   return (
     <PageAnimation className='max-w-6xl'>

--- a/src/app/(public)/terms-of-service/page.tsx
+++ b/src/app/(public)/terms-of-service/page.tsx
@@ -4,6 +4,8 @@ import { TERMS_OF_SERVICE_CONTENT } from '@/constants';
 import PageTitle from '@/components/public/page-title';
 import PageAnimation from '@/components/public/page-animation';
 
+export const revalidate = 86400;
+
 const Page: React.FC = () => {
   return (
     <PageAnimation className='max-w-6xl'>

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -1,10 +1,23 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getProductBySlug } from '@/actions/products.actions';
+import { getProductBySlug, getProducts } from '@/actions/products.actions';
 import ProductListing from "@/components/product/product-listing";
 
 type Props = {
   params: Promise<{ slug: string }>;
+}
+
+export const revalidate = 60; 
+export const dynamicParams = true; 
+
+export async function generateStaticParams() {
+  // Fetch all products to generate static paths
+  const productsResponse = await getProducts('');
+  const products = productsResponse.data?.data || [];
+
+  return products.map(product => ({
+    slug: product.slug,
+  }));
 }
 
 // Generate dynamic metadata for SEO
@@ -12,7 +25,7 @@ export async function generateMetadata(
   { params }: Props,
 ): Promise<Metadata> {
   // Get product data
-  const slug = (await params).slug;
+  const { slug } = await params;
   const productResult = await getProductBySlug({ userId: '', slug });
   
   // If product not found, return basic metadata

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,8 +9,7 @@ type SitemapItem = {
     images?: string[];
 };
 
-// Set revalidation to 1 hour (3600 seconds)
-export const revalidate = 3600;
+export const dynamic = 'force-dynamic'; 
 
 const STATIC_ROUTES = [
   { path: '', priority: 1 },


### PR DESCRIPTION
This pull request introduces changes to various pages in the application to improve caching and dynamic parameter handling. The primary focus is on adding revalidation times and dynamic parameter generation for specific pages.

### Caching Improvements:

* [`src/app/(public)/contact/page.tsx`](diffhunk://#diff-2566a5e2dd958f3191bcc9408230f466a006a81d5b25219595e4e919ce160ca6R5-R6): Added `revalidate` constant to set revalidation time to 900 seconds.
* [`src/app/(public)/how-it-works/page.tsx`](diffhunk://#diff-26bdd00e0146b52eb42a823dd16bb729549f939555bfd28e304426b1a67e8af8R11-R12): Added `revalidate` constant to set revalidation time to 86400 seconds.
* [`src/app/(public)/privacy-policy/page.tsx`](diffhunk://#diff-a4cd4574a0fbc5f352210f071866cebae2ba9cee9855333eeec735fab9dc339aR6-R7): Added `revalidate` constant to set revalidation time to 86400 seconds.
* [`src/app/(public)/terms-of-service/page.tsx`](diffhunk://#diff-dc46cf06357f3c64b17a661c8424d97084ee835edaf134a90410458ae5638dcdR7-R8): Added `revalidate` constant to set revalidation time to 86400 seconds.

### Dynamic Parameter Handling:

* `src/app/products/[slug]/page.tsx`: Added `revalidate` and `dynamicParams` constants, and implemented `generateStaticParams` function to fetch all products and generate static paths. ([src/app/products/[slug]/page.tsxL3-R28](diffhunk://#diff-0f48f17c53b6bacc40a5c2b46a312e176a75f2d254844ca4b540dca62365b667L3-R28))
* [`src/app/sitemap.ts`](diffhunk://#diff-d61cbfe152f276a1db8b4db1af2171f2d9a120bd26020f8818c602ca1477d4a1L12-R12): Changed `revalidate` to `dynamic` with the value `'force-dynamic'` to ensure dynamic content generation.