### PR TITLE
fix(payment): set default to OFFSITE payment

### DIFF
--- a/src/components/public/profile/payment-dialog.tsx
+++ b/src/components/public/profile/payment-dialog.tsx
@@ -202,7 +202,7 @@ const PAYMENT_DETAILS = {
 export function PaymentDialog({ open, onOpenChange, orderId, onPaymentComplete }: Readonly<PaymentDialogProps>) {
   const { userId } = useUserStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [activeTab, setActiveTab] = useState<PaymentSite>('ONSITE');
+  const [activeTab, setActiveTab] = useState<PaymentSite>('OFFSITE');
   const [paymentAmount, setPaymentAmount] = useState<number>(0);
   const toast = useToast;
   
@@ -212,7 +212,7 @@ export function PaymentDialog({ open, onOpenChange, orderId, onPaymentComplete }
     resolver: zodResolver(paymentFormSchema),
     defaultValues: {
       paymentMethod: undefined,
-      paymentSite: 'ONSITE',
+      paymentSite: 'OFFSITE',
       paymentType: 'FULL',
       customAmount: undefined,
       referenceNo: '',


### PR DESCRIPTION
This pull request includes changes to the `PaymentDialog` component to update the default payment site from 'ONSITE' to 'OFFSITE'. These changes are intended to modify the default behavior of the payment dialog.

Changes to the `PaymentDialog` component:

* Updated the initial state of `activeTab` to 'OFFSITE' instead of 'ONSITE' in `src/components/public/profile/payment-dialog.tsx`.
* Changed the default value of `paymentSite` to 'OFFSITE' in the form resolver's default values in `src/components/public/profile/payment-dialog.tsx`.